### PR TITLE
Remove login/logout options

### DIFF
--- a/spirit/core/templates/spirit/_header.html
+++ b/spirit/core/templates/spirit/_header.html
@@ -26,7 +26,7 @@
                                 <li><a class="menu-link" href="{% url "spirit:admin:index" %}">{% trans "Admin" %}</a></li>
                             {% endif %}
 
-                            <li><a class="menu-link js-post" href="{% url "spirit:user:auth:logout" %}?next={% firstof request.get_full_path|urlencode '/' %}">{% trans "Log out" %}</a></li>
+                            
                         </ul>
                     </nav>
                 </div>
@@ -38,7 +38,7 @@
                 </div>
 
             </div>
-        {% else %}
-            <a class="header-link" href="{% url "spirit:user:auth:login" %}?next={% firstof request.get_full_path|urlencode '/' %}">{% trans "Log in" %}</a>
+        
+            
         {% endif %}
 	</header>


### PR DESCRIPTION
I removed the options login/logout because there were two login/logout buttons, one from the general project and the second from the spirit forum